### PR TITLE
add concept of domain processor

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -1,2 +1,15 @@
 class Domain < ApplicationRecord
+  PROCESSORS = {
+    'DOJProcessor' => DOJProcessor
+  }
+
+  def perform_processor
+    processor.perform(id)
+  end
+
+  private
+
+  def processor
+    PROCESSORS.fetch(kind).new
+  end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,2 +1,3 @@
 class Location < ApplicationRecord
+  belongs_to :domain
 end

--- a/app/processors/doj_processor.rb
+++ b/app/processors/doj_processor.rb
@@ -1,0 +1,13 @@
+class DOJProcessor
+  def perform(id)
+    domain = Domain.find(id)
+
+    fetcher = DOJFetcher
+    parser = CSVParser
+    normalizer = Normalizer
+    loader = Loader
+
+    data = normalizer.normalize parser.parse fetcher.fetch domain
+    loader.load! data, domain: domain
+  end
+end

--- a/app/processors/loader.rb
+++ b/app/processors/loader.rb
@@ -2,7 +2,7 @@ class Loader
   Result = ImmutableStruct.new :success?, :error
   ERROR_MESSAGE = 'ERROR: Processor::Loader.load! transaction failed!'
 
-  def self.load!(data, klass: Location)
+  def self.load!(data, klass: Location, **kwargs)
     begin
       ActiveRecord::Base.transaction do
         data.each do |record|
@@ -14,6 +14,7 @@ class Loader
             website:          record[:website],
             services:         record[:services],
             type_of_services: record[:type],
+            **kwargs
           )
         end
       end

--- a/db/migrate/20170520002300_add_domain_to_locations.rb
+++ b/db/migrate/20170520002300_add_domain_to_locations.rb
@@ -1,0 +1,5 @@
+class AddDomainToLocations < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :locations, :domain, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,6 +55,8 @@ ActiveRecord::Schema.define(version: 20170520004548) do
     t.string "type_of_services"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "domain_id"
+    t.index ["domain_id"], name: "index_locations_on_domain_id"
   end
 
   create_table "services", force: :cascade do |t|
@@ -66,4 +68,5 @@ ActiveRecord::Schema.define(version: 20170520004548) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "locations", "domains"
 end

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -2,6 +2,6 @@ require "test_helper"
 
 describe Location do
   it 'must be valid' do
-    assert_equal true, Location.new.valid?
+    assert_equal true, Location.new(domain: Domain.new).valid?
   end
 end

--- a/test/processors/doj_fetcher_test.rb
+++ b/test/processors/doj_fetcher_test.rb
@@ -11,6 +11,8 @@ class DOJFetcherTest < ActiveSupport::TestCase
 
   describe '.fetch' do
     it 'retrieves data from the DOJ PDF URL' do
+      skip('this test is slower') if ENV['TEST_FASTER']
+
       csv_file = Rails.root + 'test/fixtures/files/doj-data.csv'
       expected = File.read(csv_file)
 

--- a/test/processors/doj_processor_test.rb
+++ b/test/processors/doj_processor_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class DOJProcessorTest < ActiveSupport::TestCase
+  let(:domain) do
+    Domain.create(
+      kind: 'DOJProcessor',
+      url: 'https://www.justice.gov/usao-md/page/file/941351/download'
+    )
+  end
+
+  describe '#perform' do
+    it 'transforms and loads data from the DOJ PDF URL' do
+      VCR.use_cassette('doj_pdf_fetcher') do
+        domain.perform_processor
+      end
+
+      relation = Location
+                 .where(domain: domain)
+                 .where.not(name: nil)
+                 .order(:name)
+
+      assert_equal 'AAMC Community Health Center',
+                   relation.first.name
+
+      assert_equal 'Youth Empowered Society (YES) Drop- In Center',
+                   relation.last(2).first.name
+    end
+  end
+end

--- a/test/processors/doj_processor_test.rb
+++ b/test/processors/doj_processor_test.rb
@@ -10,6 +10,8 @@ class DOJProcessorTest < ActiveSupport::TestCase
 
   describe '#perform' do
     it 'transforms and loads data from the DOJ PDF URL' do
+      skip('This test is slower') if ENV['TEST_FASTER']
+
       VCR.use_cassette('doj_pdf_fetcher') do
         domain.perform_processor
       end

--- a/test/processors/loader_test.rb
+++ b/test/processors/loader_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class LoaderTest < ActiveSupport::TestCase
+  let(:domain) { Domain.create }
   let(:loader) { Loader }
 
   before(:each) do
@@ -10,13 +11,13 @@ class LoaderTest < ActiveSupport::TestCase
   describe '.load!' do
     describe 'successfully' do
       it 'creates ActiveRecord objects from the supplied array of data' do
-        loader.load!(parsed_array)
+        loader.load!(parsed_array, domain: domain)
 
         assert_equal 2, Location.count
       end
 
       it 'returns a successful Result object with no errors' do
-        result = loader.load!(parsed_array)
+        result = loader.load!(parsed_array, domain: domain)
 
         assert_instance_of Loader::Result, result
         assert_equal true, result.success?
@@ -26,7 +27,7 @@ class LoaderTest < ActiveSupport::TestCase
 
     describe 'unsuccessfully' do
       it 'does not create ActiveRecord objects from the supplied array of data' do
-        loader.load!([])
+        loader.load!([], domain: domain)
 
         assert_equal 0, Location.count
       end


### PR DESCRIPTION
we create a processor for each unique domain to gather data from that domain;
the #perform method on a domain-attached processor serves to kick off a run of
the scrape and/or crawl, and should be suitable for use in a controller, rake
task, or background job

we use the example of DOJProcessor to test out Domain#perform_processor, which
is the likely entrypoint for the above contexts

TODO: refactor to use Composer
TODO: better errors (test the failure cases)