### PR TITLE
add tests for domain_services & location_services

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,4 +1,6 @@
 class Location < ApplicationRecord
   belongs_to :domain, optional: true
   has_many :phone_numbers
+  has_many :location_services
+  has_many :services, through: :location_services
 end

--- a/app/processors/baltimore_fetcher.rb
+++ b/app/processors/baltimore_fetcher.rb
@@ -20,6 +20,8 @@ class BaltimoreFetcher
       record[:phone] = [record[:phone]]
       record[:longitude] = entry["location_1"]["coordinates"].first.to_s
       record[:latitude] = entry["location_1"]["coordinates"].last.to_s
+      record[:service_description] = entry['type']
+      record[:services] = ServiceNormalizer.normalize(entry['type'])
       record
     end
   end

--- a/app/processors/location_loader.rb
+++ b/app/processors/location_loader.rb
@@ -11,12 +11,19 @@ class LocationLoader
             name:             record[:name],
             address:          record[:address],
             website:          record[:website],
-            services:         record[:services],
-            type_of_services: record[:type],
+            service_description: record[:service_description],
+            type_of_services: record[:type_of_services],
             latitude:         record[:latitude],
             longitude:        record[:longitude],
             **kwargs
           )
+
+          record.fetch(:services, []).each do |name|
+            service = Service.find_by(name: name)
+            next unless service
+            next if location.services.include?(service)
+            location.services << service
+          end
 
           record[:phone].each_with_index do |phone_number, index|
             PhoneNumber.find_or_create_by!(

--- a/app/processors/normalizer.rb
+++ b/app/processors/normalizer.rb
@@ -1,5 +1,7 @@
 class Normalizer
-  def self.normalize(parsed_array, phone_normalizer: PhoneNormalizer)
+  def self.normalize(parsed_array,
+                     phone_normalizer: PhoneNormalizer,
+                     service_normalizer: ServiceNormalizer)
     parsed_array.map do |org_hash|
       {
         county:           org_hash[:county],
@@ -7,7 +9,8 @@ class Normalizer
         address:          org_hash[:address],
         phone:            phone_normalizer.normalize(org_hash[:phone]),
         website:          org_hash[:website],
-        services:         org_hash[:services],
+        service_description: org_hash[:services],
+        services:         service_normalizer.normalize(org_hash[:type]),
         type_of_services: org_hash[:type]
       }
     end

--- a/app/processors/normalizers/service_normalizer.rb
+++ b/app/processors/normalizers/service_normalizer.rb
@@ -1,0 +1,37 @@
+class ServiceNormalizer
+  SERVICE_SYNONYMS = {
+    'Multi' => [],
+    'Support Group' => ['Support Groups'],
+  }
+
+  class << self
+    def normalize(service_data_string)
+      return [] unless service_data_string
+      service_data_string = service_data_string.titleize
+
+      normalize_as_single_phrase(service_data_string) do
+        normalize_by_subphrases(service_data_string) do
+          [service_data_string]
+        end
+      end
+    end
+
+    private
+
+    def normalize_as_single_phrase(service_data_string)
+      SERVICE_SYNONYMS.fetch(service_data_string) do
+        return yield
+      end
+    end
+
+    def normalize_by_subphrases(service_data_string)
+      return yield unless service_data_string.include?('&')
+
+      service_data_string.split(/ *& */).flat_map do |subphrase|
+        normalize_as_single_phrase(subphrase) do
+          [subphrase]
+        end
+      end
+    end
+  end
+end

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -21,7 +21,7 @@
         <td><%= location.address %></td>
         <td><%= location.phone %></td>
         <td><%= location.website %></td>
-        <td><%= location.services %></td>
+        <td><%= location.service_description %></td>
         <td><%= location.type_of_services %></td>
         <td><%= location.updated_at.to_date %></td>
         <td><%= location.longitude %></td>

--- a/db/migrate/20170520195550_recreate_services_join_tables.rb
+++ b/db/migrate/20170520195550_recreate_services_join_tables.rb
@@ -1,0 +1,20 @@
+class RecreateServicesJoinTables < ActiveRecord::Migration[5.1]
+  def change
+    drop_table :domain_services
+    drop_table :location_services
+
+    create_table :domain_services do |t|
+      t.references :domain, null: false, foreign_key: true
+      t.references :service, null: false, foreign_key: true
+      t.boolean  :active, null: false, default: true
+      t.timestamps
+    end
+
+    create_table :location_services do |t|
+      t.references :location, null: false, foreign_key: true
+      t.references :service, null: false, foreign_key: true
+      t.boolean  :active, null: false, default: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170520202624_remove_services_from_locations.rb
+++ b/db/migrate/20170520202624_remove_services_from_locations.rb
@@ -1,0 +1,5 @@
+class RemoveServicesFromLocations < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :locations, :services, :service_description
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170520195550) do
+ActiveRecord::Schema.define(version: 20170520202624) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(version: 20170520195550) do
     t.string "address"
     t.string "phone"
     t.string "website"
-    t.string "services"
+    t.string "service_description"
     t.string "type_of_services"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170520182502) do
+ActiveRecord::Schema.define(version: 20170520195550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,11 +26,13 @@ ActiveRecord::Schema.define(version: 20170520182502) do
   end
 
   create_table "domain_services", force: :cascade do |t|
-    t.string "domain_id"
-    t.string "service_id"
+    t.bigint "domain_id", null: false
+    t.bigint "service_id", null: false
     t.boolean "active", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["domain_id"], name: "index_domain_services_on_domain_id"
+    t.index ["service_id"], name: "index_domain_services_on_service_id"
   end
 
   create_table "domains", force: :cascade do |t|
@@ -54,11 +56,13 @@ ActiveRecord::Schema.define(version: 20170520182502) do
   end
 
   create_table "location_services", force: :cascade do |t|
-    t.string "location_id"
-    t.string "service_id"
+    t.bigint "location_id", null: false
+    t.bigint "service_id", null: false
     t.boolean "active", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_location_services_on_location_id"
+    t.index ["service_id"], name: "index_location_services_on_service_id"
   end
 
   create_table "locations", force: :cascade do |t|
@@ -95,5 +99,9 @@ ActiveRecord::Schema.define(version: 20170520182502) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "domain_services", "domains"
+  add_foreign_key "domain_services", "services"
+  add_foreign_key "location_services", "locations"
+  add_foreign_key "location_services", "services"
   add_foreign_key "locations", "domains"
 end

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -6,7 +6,7 @@ one:
   address: MyString
   phone: MyString
   website: MyString
-  services: MyString
+  service_description: MyString
   type_of_services: MyString
 
 two:
@@ -15,5 +15,5 @@ two:
   address: MyString
   phone: MyString
   website: MyString
-  services: MyString
+  service_description: MyString
   type_of_services: MyString

--- a/test/fixtures/services.yml
+++ b/test/fixtures/services.yml
@@ -5,3 +5,9 @@ one:
 
 two:
   name: MyString
+
+'Emergency Shelter':
+  name: 'Emergency Shelter'
+
+'Food':
+  name: 'Food'

--- a/test/models/domain_test.rb
+++ b/test/models/domain_test.rb
@@ -1,7 +1,20 @@
 require 'test_helper'
 
-class DomainTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+describe Domain do
+  it 'must be valid' do
+    assert_equal true, Domain.new.valid?
+  end
+
+  describe '#services' do
+    it 'returns an array' do
+      assert_equal [], Domain.create.services.to_a
+    end
+
+    it 'returns a collection of Service' do
+      service = Service.create
+      domain = Domain.create
+      domain.services << service
+      assert domain.services.include?(service)
+    end
+  end
 end

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -4,4 +4,19 @@ describe Location do
   it 'must be valid' do
     assert_equal true, Location.new(domain: Domain.new).valid?
   end
+
+  describe '#services' do
+    it 'returns an array' do
+      skip "services is both a columns and an association currently"
+      assert_equal [], Location.create.services.to_a
+    end
+
+    it 'returns a collection of Service' do
+      skip "services is both a column and an association currently"
+      service = Service.create
+      location = Location.create(domain: Domain.new)
+      location.services << service
+      assert location.services.include?(service)
+    end
+  end
 end

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -7,12 +7,10 @@ describe Location do
 
   describe '#services' do
     it 'returns an array' do
-      skip "services is both a columns and an association currently"
       assert_equal [], Location.create.services.to_a
     end
 
     it 'returns a collection of Service' do
-      skip "services is both a column and an association currently"
       service = Service.create
       location = Location.create(domain: Domain.new)
       location.services << service

--- a/test/processors/baltimore_processor_test.rb
+++ b/test/processors/baltimore_processor_test.rb
@@ -28,4 +28,17 @@ class BaltimoreProcessorTest < ActiveSupport::TestCase
     assert test_location.latitude, "-76.644556"
     assert test_location.longitude, "39.301778"
   end
+
+  it 'associates created locations with services' do
+    VCR.use_cassette('baltimore_json_fetcher') do
+      domain.perform_processor
+    end
+
+    location = Location.find_by(domain: domain,
+                                service_description: 'Emergency Shelter')
+
+    assert location, 'Location missing'
+    refute_empty location.services
+    assert_equal 'Emergency Shelter', location.services.first.name
+  end
 end

--- a/test/processors/doj_processor_test.rb
+++ b/test/processors/doj_processor_test.rb
@@ -11,6 +11,7 @@ class DOJProcessorTest < ActiveSupport::TestCase
   describe '#perform' do
     it 'transforms and loads data from the DOJ PDF URL' do
       skip('This test is slower') if ENV['TEST_FASTER']
+      Service.create(name: 'Food')
 
       VCR.use_cassette('doj_pdf_fetcher') do
         domain.perform_processor
@@ -29,6 +30,10 @@ class DOJProcessorTest < ActiveSupport::TestCase
 
       assert_equal 'Youth Empowered Society (YES) Drop- In Center',
                    names.last
+
+      location = Location.find_by(domain: domain, type_of_services: 'Food')
+      assert location, 'Location missing'
+      assert_equal ['Food'], location.services.map(&:name)
     end
   end
 end

--- a/test/processors/location_loader_test.rb
+++ b/test/processors/location_loader_test.rb
@@ -48,8 +48,9 @@ class LocationLoaderTest < ActiveSupport::TestCase
         :address          => 'Various locations',
         :phone            => ['222-333-4444', '1-888-234-1122'],
         :website          => 'www.westernmarylandaa.org',
-        :services         => 'Support services',
-        :type_of_services => 'Substance Abuse',
+        :services         => [],
+        :service_description => 'Support services',
+        :type_of_services => 'Substance Abuse'
       },
       {
         :county           => 'Anne Arundel',
@@ -57,8 +58,9 @@ class LocationLoaderTest < ActiveSupport::TestCase
         :address          => '10 Hudson Street Annapolis, MD 21401',
         :phone            => ['(410) 349-5056'],
         :website          => 'www.annapolislighthouse.org',
-        :services         => 'Emergency shelter',
-        :type_of_services => 'Shelter',
+        :services         => [],
+        :service_description => 'Emergency shelter',
+        :type_of_services => 'Shelter'
       }
     ]
   end

--- a/test/processors/normalizers/service_normalizer_test.rb
+++ b/test/processors/normalizers/service_normalizer_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+describe ServiceNormalizer do
+  let(:normalizer) { ServiceNormalizer }
+
+  describe '.normalize' do
+    describe 'with a single word' do
+      it 'returns an array of one string' do
+        services = 'Veterans'
+        assert_equal ['Veterans'],
+                     normalizer.normalize(services)
+      end
+    end
+
+    describe 'with single 2-word phrase' do
+      it 'returns an array of one string' do
+        services = 'Support Services'
+        assert_equal ['Support Services'],
+                     normalizer.normalize(services)
+      end
+    end
+
+    describe 'with phrases separated by ampersands' do
+      it 'returns an array of strings' do
+        services = 'Food & Housing'
+        assert_equal ['Food', 'Housing'],
+                     normalizer.normalize(services)
+      end
+    end
+
+    {
+      nil => [],
+      'Education' => ['Education'],
+      'food' => ['Food'],
+      'Food & Housing' => ['Food', 'Housing'],
+      'Housing' => ['Housing'],
+      'Legal' => ['Legal'],
+      'Multi' => [],
+      'Support Group' => ['Support Groups'],
+      'Support group' => ['Support Groups']
+    }.each_pair do |input, output|
+      it "converts #{input.inspect} to #{output.inspect}" do
+        assert_equal output, normalizer.normalize(input)
+      end
+    end
+  end
+end


### PR DESCRIPTION
needed a migration to re-type the reference columns; since we are pre-production
we don't make any attempt to cast strings to integers and instead drop and
recreate those tables

Testing showed that `Location#services` was not functioning as an association, so the following additional changes were made:

* rename locations.services to locations.service_description
* add location<->services assocation
* add ServiceNormalizer to extract services from type_of_services during
  normalization